### PR TITLE
Return static vectors from `incident` for unique-indexed columns

### DIFF
--- a/src/ColumnImplementations.jl
+++ b/src/ColumnImplementations.jl
@@ -57,18 +57,6 @@ struct DenseInjectiveFinColumn{V<:AbstractVector{Int}} <: Column{Int,Int}
   pc::InjectiveCache{Int, Int, VecMap{Int, Vector{Int}}}
 end
 
-# Compatibility hack to support unique_index
-function Columns.preimage(dom, c::DenseInjectiveFinColumn, y::Int, ::UnboxInjectiveFlag)
-  # @warn "using old convention for preimage of unique-indexed homomorphisms"
-  get(c.pc.inverse, y, 0)
-end
-
-function Columns.preimage_multi(dom, c::DenseInjectiveFinColumn, ys, ::UnboxInjectiveFlag)
-  # @warn "using old convention for preimage of unique-indexed homomorphisms"
-  view_with_default(c.pc.inverse, ys, DefaultVal{0})
-end
-
-
 """
 A column for a dict-backed unindexed hom with key type K
 """
@@ -120,19 +108,6 @@ A column for a vec-backed unindexed attr
 struct DenseInjectiveColumn{T, V<:AbstractVector{T}} <: Column{Int,T}
   m::VecMap{T,V}
   pc::InjectiveCache{Int,T,DictMap{T,Int,Dict{T,Int}}}
-end
-
-# Compatibility hack
-function Columns.preimage(dom, c::DenseInjectiveColumn{T}, y::T, ::UnboxInjectiveFlag) where {T}
-  # @warn "using old convention for preimage of unique-indexed attributes"
-  get(c.pc.inverse.d, y, 0)
-end
-
-function Columns.preimage_multi(dom, c::DenseInjectiveColumn, ys, ::UnboxInjectiveFlag)
-  # @warn "using old convention for preimage of unique-indexed attributes"
-  broadcast(ys) do y
-    get(c.pc.inverse.d, y, 0)
-  end
 end
 
 """

--- a/src/Columns.jl
+++ b/src/Columns.jl
@@ -1,7 +1,6 @@
 module Columns
 export Mapping, PreimageCache, preimage, preimage_multi, add_mapping!, remove_mapping!,
-  Column, preimage, preimage_multi, undefine!,
-  UnboxInjectiveFlag
+  Column, preimage, preimage_multi, undefine!
 
 using MLStyle
 using StructEquality
@@ -55,14 +54,6 @@ function Base.setindex!(c::Column, y, x)
   assign!(c.pc, y, x)
   c.m[x] = y
 end
-
-# This is to maintain compatibility with old convention for unique_indexing
-struct UnboxInjectiveFlag end
-
-# This is overloaded for specific columns to enable the old convention
-preimage(dom, c::Column, y, ::UnboxInjectiveFlag) = preimage(dom, c, y)
-
-preimage_multi(dom, c::Column, ys, ::UnboxInjectiveFlag) = preimage_multi(dom, c, ys)
 
 preimage(dom, c::Column, y) = preimage(dom, c.m, c.pc, y)
 

--- a/src/DenseACSets.jl
+++ b/src/DenseACSets.jl
@@ -412,9 +412,8 @@ equivalent to concatenating the results of incident on each part, i.e.
 """
 @inline function ACSetInterface.incident(acs::SimpleACSet, 
     parts::Union{AbstractVector,UnitRange}, f::Symbol)
-  T = isempty(parts) ? Vector{Int} : typeof(incident(acs, first(parts), f))
-  res = T[incident(acs, part, f) for part in parts]
-  return res # FIXME: update preimage_multi to work on attrs for better performance
+  # FIXME: update preimage_multi to work on attrs for better performance
+  AbstractVector{Int}[incident(acs, part, f) for part in parts]
 end 
 
 @inline ACSetInterface.incident(acs::StructACSet{S}, ::Colon, f::Symbol) where {S} =

--- a/test/ACSets.jl
+++ b/test/ACSets.jl
@@ -273,7 +273,7 @@ SchSubset = BasicSchema([:Set,:Sub], [(:ι,:Sub,:Set)])
 
 @acset_type Subset(SchSubset, unique_index=[:ι])
 
-Base.in(x, X::Subset) = !isempty(incident(X, x, :ι))
+Base.in(x::Integer, X::Subset) = !isempty(incident(X, x, :ι))
 
 A = Subset()
 add_parts!(A, :Set, 2)
@@ -283,6 +283,9 @@ add_parts!(B, :Set, 2)
 add_part!(B, :Sub, ι=2)
 @test 1 ∈ A && 2 ∉ A
 @test 1 ∉ B && 2 ∈ B
+@test incident(A, :, :ι) == [[1], []]
+@test incident(B, :, :ι) == [[], [1]]
+
 rem_part!(A, :Set, 2)
 @test 1 ∈ A
 rem_part!(B, :Set, 1)

--- a/test/ACSets.jl
+++ b/test/ACSets.jl
@@ -1,8 +1,10 @@
 module TestCSetDataStructures
 using Test
 
-using ACSets
+using StaticArrays: StaticVector
 using Tables
+
+using ACSets
 
 # Discrete dynamical systems
 ############################
@@ -271,7 +273,7 @@ SchSubset = BasicSchema([:Set,:Sub], [(:ι,:Sub,:Set)])
 
 @acset_type Subset(SchSubset, unique_index=[:ι])
 
-Base.in(x, X::Subset) = incident(X, x, :ι) != 0
+Base.in(x, X::Subset) = !isempty(incident(X, x, :ι))
 
 A = Subset()
 add_parts!(A, :Set, 2)
@@ -358,14 +360,15 @@ for lset_maker in lset_makers
   lset = lset_maker(Symbol)
   add_parts!(lset, :X, 2, label=[:foo, :bar])
   @test subpart(lset, :, :label) == [:foo, :bar]
-  @test incident(lset, :foo, :label) == 1
-  @test incident(lset, [:foo,:bar], :label) == [1,2]
-  @test incident(lset, :nonkey, :label) == 0
+  @test incident(lset, :foo, :label) isa StaticVector
+  @test incident(lset, :foo, :label) == [1]
+  @test incident(lset, [:foo,:bar], :label) == [[1],[2]]
+  @test isempty(incident(lset, :nonkey, :label))
 
   set_subpart!(lset, 1, :label, :baz)
   @test subpart(lset, 1, :label) == :baz
-  @test incident(lset, :baz, :label) == 1
-  @test incident(lset, :foo, :label) == 0
+  @test incident(lset, :baz, :label) == [1]
+  @test isempty(incident(lset, :foo, :label))
 
   @test_throws Exception set_subpart!(lset, 1, :label, :bar)
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 ACSets = "227ef7b5-1206-438b-ac65-934d6da304b8"
 JSONSchema = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
This is a long overdue change that is important for consistency and predictability. It may be a small change but be warned that it is definitely breaking!

Closes #15.