### PR TITLE
Collect by default, opt-in for view of column data

### DIFF
--- a/src/ACSetInterface.jl
+++ b/src/ACSetInterface.jl
@@ -102,13 +102,8 @@ function subpart(acs, part, names::AbstractVector{Symbol})
   end
 end
 
-subpart(acs, names::AbstractVector{Symbol}) =
-  subpart(acs, Int[subpart(acs, names[1])...], names[2:end])
-
 Base.getindex(acs::ACSet, part, name) = subpart(acs, part, name)
 Base.getindex(acs::ACSet, name) = subpart(acs, name)
-Base.view(acs::ACSet, name) = view(acs,name)
-Base.view(acs::ACSet, part, name) = view(acs,name)[part]
 
 
 """ Get superparts incident to part in acset.

--- a/src/ACSetInterface.jl
+++ b/src/ACSetInterface.jl
@@ -107,6 +107,8 @@ subpart(acs, names::AbstractVector{Symbol}) =
 
 Base.getindex(acs::ACSet, part, name) = subpart(acs, part, name)
 Base.getindex(acs::ACSet, name) = subpart(acs, name)
+Base.view(acs::ACSet, name) = view(acs,name)
+Base.view(acs::ACSet, part, name) = view(acs,name)[part]
 
 
 """ Get superparts incident to part in acset.

--- a/src/DenseACSets.jl
+++ b/src/DenseACSets.jl
@@ -385,7 +385,16 @@ Base.view(acs::SimpleACSet, ::Colon, f) = view(acs, dom_parts(acs,f), f)
 
 @inline ACSetInterface.subpart(acs::SimpleACSet, f::Symbol) = subpart(acs, dom_parts(acs, f), f)
 @inline ACSetInterface.subpart(acs::SimpleACSet, f::Vector{Symbol}) = subpart(acs, dom_parts(acs, first(f)), f)
-@inline ACSetInterface.subpart(acs::ACSet, part::Union{Colon,AbstractVector,UnitRange}, name::Symbol) = identity.(view(acs, part, name))
+@inline ACSetInterface.subpart(acs::ACSet, part::Union{Colon,AbstractVector}, name::Symbol) =
+  collect_column(view(acs, part, name))
+
+function collect_column(x::AbstractVector)
+  if isempty(x)
+    Base.typesplit(eltype(x), AttrVar)[]
+  else
+    map(identity, x)
+  end
+end
 
 @inline ACSetInterface.subpart(acs::SimpleACSet, part::Int, f::Symbol) =
   get(acs.subparts[f], part, default_value(acs, f))

--- a/src/DenseACSets.jl
+++ b/src/DenseACSets.jl
@@ -376,8 +376,10 @@ end
   end
 end
 
-@inline ACSetInterface.subpart(acs::SimpleACSet, f::Symbol) =
+@inline Base.view(acs::SimpleACSet, f::Symbol) =
   view_with_default(acs.subparts[f], dom_parts(acs, f), default_value(acs, f))
+
+@inline ACSetInterface.subpart(acs::SimpleACSet, f::Symbol) = identity.(view(acs,f))
 
 @inline ACSetInterface.subpart(acs::SimpleACSet, part::Int, f::Symbol) =
   get(acs.subparts[f], part, default_value(acs, f))

--- a/src/DenseACSets.jl
+++ b/src/DenseACSets.jl
@@ -376,15 +376,21 @@ end
   end
 end
 
+Base.view(acs::SimpleACSet, part, f) = view_with_default(acs.subparts[f], part, default_value(acs, f))
+Base.view(acs::SimpleACSet, part::AbstractVector{Bool}, f) = view(acs, f)[part]
+Base.view(acs::SimpleACSet, ::Colon, f) = view(acs, dom_parts(acs,f), f)
+
 @inline Base.view(acs::SimpleACSet, f::Symbol) =
   view_with_default(acs.subparts[f], dom_parts(acs, f), default_value(acs, f))
 
-@inline ACSetInterface.subpart(acs::SimpleACSet, f::Symbol) = identity.(view(acs,f))
+@inline ACSetInterface.subpart(acs::SimpleACSet, f::Symbol) = subpart(acs, dom_parts(acs, f), f)
+@inline ACSetInterface.subpart(acs::SimpleACSet, f::Vector{Symbol}) = subpart(acs, dom_parts(acs, first(f)), f)
+@inline ACSetInterface.subpart(acs::ACSet, part::Union{Colon,AbstractVector,UnitRange}, name::Symbol) = identity.(view(acs, part, name))
 
 @inline ACSetInterface.subpart(acs::SimpleACSet, part::Int, f::Symbol) =
   get(acs.subparts[f], part, default_value(acs, f))
 
-@inline ACSetInterface.has_subpart(acs::StructACSet{S}, f::Symbol) where {S} =
+@inline ACSetInterface.has_subpart(::StructACSet{S}, f::Symbol) where {S} =
   _has_subpart(Val{S}, Val{f})
 
 ACSetInterface.has_subpart(acs::DynamicACSet, f::Symbol) =

--- a/test/ACSets.jl
+++ b/test/ACSets.jl
@@ -43,6 +43,7 @@ for dds_maker in dds_makers
   @test add_part!(dds, :X, Φ=1) == 3
   @test subpart(dds, :Φ) == [1,1,1]
   @test subpart(dds, [2,3], :Φ) == [1,1]
+  @test subpart(dds, Bool[0,1,1], :Φ) == [1,1]
   @test incident(dds, 1, :Φ) == [1,2,3]
 
   @test has_part(dds, :X)
@@ -62,6 +63,8 @@ for dds_maker in dds_makers
   add_parts!(dds, :X, 3, Φ=[2,3,3])
   dds[1:2,:Φ] isa Vector{Int}
   dds[:Φ] isa Vector{Int}
+  dds[[:Φ,:Φ]] isa Vector{Int}
+  dds[1:2, [:Φ,:Φ]] isa Vector{Int}
   view(dds,1:2,:Φ) isa ColumnView
   view(dds,:Φ) isa ColumnView
   rem_part!(dds, :X, 2)

--- a/test/ACSets.jl
+++ b/test/ACSets.jl
@@ -5,6 +5,7 @@ using StaticArrays: StaticVector
 using Tables
 
 using ACSets
+using ACSets.Columns: ColumnView
 
 # Discrete dynamical systems
 ############################
@@ -59,6 +60,10 @@ for dds_maker in dds_makers
   # Deletion.
   dds = dds_maker()
   add_parts!(dds, :X, 3, Φ=[2,3,3])
+  dds[1:2,:Φ] isa Vector{Int}
+  dds[:Φ] isa Vector{Int}
+  view(dds,1:2,:Φ) isa ColumnView
+  view(dds,:Φ) isa ColumnView
   rem_part!(dds, :X, 2)
   @test nparts(dds, :X) == 2
   @test subpart(dds, :Φ) == [0,2]

--- a/test/ACSets.jl
+++ b/test/ACSets.jl
@@ -58,7 +58,7 @@ for dds_maker in dds_makers
   @test_throws Exception incident(dds, 1, :nonsuppart)
   @test_throws Exception set_subpart!(dds, 1, :nonsubpart, 1)
 
-  # Deletion.
+  # Types of subset-ed columns.
   dds = dds_maker()
   add_parts!(dds, :X, 3, Φ=[2,3,3])
   dds[1:2,:Φ] isa Vector{Int}
@@ -67,6 +67,8 @@ for dds_maker in dds_makers
   dds[1:2, [:Φ,:Φ]] isa Vector{Int}
   view(dds,1:2,:Φ) isa ColumnView
   view(dds,:Φ) isa ColumnView
+
+  # Deletion.
   rem_part!(dds, :X, 2)
   @test nparts(dds, :X) == 2
   @test subpart(dds, :Φ) == [0,2]


### PR DESCRIPTION
the earlier `subpart(acs::ACSet,f::Symbol)` behavior is now the `Base.view` behavior, and `subpart` now maps `identity` over this view (to produce a `Vector` which, if there are no AttrVars, will be just `Vector{Float64}`, for example, rather than `Vector{Union{Float64,AttrVar}}`.

I was unsure whether I should also replace 

```@inline Base.@propagate_inbounds subpart(acs, part, name) = view_or_slice(subpart(acs, name), part)```

with 

```
@inline Base.@propagate_inbounds subpart(acs, part, name) =subpart(acs, name)[part]
```

given that `subpart(acs, name)` is already a vector rather than a column view, now.
