### PR TITLE
Reindex attribute variables in `copy_parts!`

### DIFF
--- a/src/DenseACSets.jl
+++ b/src/DenseACSets.jl
@@ -632,7 +632,16 @@ ACSetInterface.copy_parts_only!(to::ACSet, from::ACSet, parts::NamedTuple) =
   ),))
 
   @ct_ctrl for (a,d,c) in relevant_attrs
-    set_subpart!(to, newparts[@ct d], @ct(a), subpart(from, parts[@ct d], @ct(a)))
+    for (part, val) in zip(newparts[@ct d], subpart(from, parts[@ct d], @ct(a)))
+      if !(val isa AttrVar)
+        v = val 
+      elseif !haskey(newparts, @ct(c))
+        v = AttrVar(0)
+      else
+        v = AttrVar(newparts[@ct c][findfirst(==(val.val), parts[@ct c])])
+      end
+      set_subpart!(to, part, @ct(a), v)
+    end
   end
 
   newparts

--- a/src/DenseACSets.jl
+++ b/src/DenseACSets.jl
@@ -634,13 +634,11 @@ ACSetInterface.copy_parts_only!(to::ACSet, from::ACSet, parts::NamedTuple) =
   @ct_ctrl for (a,d,c) in relevant_attrs
     for (part, val) in zip(newparts[@ct d], subpart(from, parts[@ct d], @ct(a)))
       if !(val isa AttrVar)
-        v = val 
-      elseif !haskey(newparts, @ct(c))
-        v = AttrVar(0)
-      else
+        set_subpart!(to, part, @ct(a), val)
+      elseif haskey(newparts, @ct(c))
         v = AttrVar(newparts[@ct c][findfirst(==(val.val), parts[@ct c])])
+        set_subpart!(to, part, @ct(a), v)
       end
-      set_subpart!(to, part, @ct(a), v)
     end
   end
 

--- a/src/DenseACSets.jl
+++ b/src/DenseACSets.jl
@@ -635,9 +635,11 @@ ACSetInterface.copy_parts_only!(to::ACSet, from::ACSet, parts::NamedTuple) =
     for (part, val) in zip(newparts[@ct d], subpart(from, parts[@ct d], @ct(a)))
       if !(val isa AttrVar)
         set_subpart!(to, part, @ct(a), val)
-      elseif haskey(newparts, @ct(c))
-        v = AttrVar(newparts[@ct c][findfirst(==(val.val), parts[@ct c])])
-        set_subpart!(to, part, @ct(a), v)
+      else
+        newindex = findfirst(==(val.val), get(parts, @ct(c), []))
+        if !isnothing(newindex)
+          set_subpart!(to, part, @ct(a), AttrVar(newparts[@ct c][newindex]))
+        end
       end
     end
   end

--- a/test/ACSets.jl
+++ b/test/ACSets.jl
@@ -188,7 +188,8 @@ dgram_makers = [
 for (dgram_maker, ldgram_maker) in dgram_makers
   d = dgram_maker(Int)
   add_parts!(d, :X, 3, height=0)
-  add_parts!(d, :X, 2, height=[10,20])
+  add_parts!(d, :R, 2)
+  add_parts!(d, :X, 2, height=[10,AttrVar(add_part!(d,:R))])
   set_subpart!(d, 1:3, :parent, 4)
   set_subpart!(d, [4,5], :parent, 5)
 
@@ -201,7 +202,7 @@ for (dgram_maker, ldgram_maker) in dgram_makers
   @test has_subpart(d, :height)
   @test subpart(d, [1,2,3], :height) == [0,0,0]
   @test subpart(d, 4, :height) == 10
-  @test subpart(d, :, :height) == [0,0,0,10,20]
+  @test subpart(d, :, :height) == [0,0,0,10,AttrVar(3)]
 
   # Chained accessors.
   @test subpart(d, 3, [:parent, :parent]) == 5
@@ -212,7 +213,7 @@ for (dgram_maker, ldgram_maker) in dgram_makers
   # Indexing syntax.
   @test d[3, :parent] == 4
   @test d[3, [:parent, :height]] == 10
-  @test d[3:5, [:parent, :height]] == [10,20,20]
+  @test d[3:5, [:parent, :height]] == [10,AttrVar(3),AttrVar(3)]
   @test d[:, :parent] == [4,4,4,5,5]
   d2 = copy(d)
   d2[1, :parent] = 1
@@ -223,15 +224,15 @@ for (dgram_maker, ldgram_maker) in dgram_makers
 
   # Copying parts.
   d2 = dgram_maker(Int)
-  copy_parts!(d2, d, X=[4,5])
+  copy_parts!(d2, d, X=[4,5], R=[3])
   @test nparts(d2, :X) == 2
   @test subpart(d2, [1,2], :parent) == [2,2]
-  @test subpart(d2, [1,2], :height) == [10,20]
+  @test subpart(d2, [1,2], :height) == [10, AttrVar(1)]
 
   du = disjoint_union(d, d2)
   @test nparts(du, :X) == 7
   @test subpart(du, :parent) == [4,4,4,5,5,7,7]
-  @test subpart(du, :height) == [0,0,0,10,20,10,20]
+  @test subpart(du, :height) == [0,0,0,10,AttrVar(3),10,AttrVar(4)]
 
   # Pretty printing of data attributes.
   s = sprint(show, d)


### PR DESCRIPTION
Addresses https://github.com/AlgebraicJulia/ACSets.jl/issues/38 by modifying `_copy_parts_only!`. "Dangling" AttrVars are left undefined, just as with combinatorial data (if an edge is copied over but not its corresponding src/tgt).