### PR TITLE
ENH: add support for ACSpec ADT

### DIFF
--- a/src/ACSets.jl
+++ b/src/ACSets.jl
@@ -13,11 +13,13 @@ include("Schemas.jl")
 include("ACSetInterface.jl")
 include("DenseACSets.jl")
 include("JSONACSets.jl")
+include("ADTs.jl")
 
 @reexport using .ColumnImplementations: AttrVar
 @reexport using .Schemas
 @reexport using .ACSetInterface
 @reexport using .DenseACSets
-@reexport using. JSONACSets
+@reexport using .JSONACSets
+@reexport using .ADTs
 
 end

--- a/src/ADTs.jl
+++ b/src/ADTs.jl
@@ -1,0 +1,196 @@
+module ADTs
+export Value, Kwarg, Args, Statement, ACSetSpec,
+ construct, acsetspec, generate_expr,
+to_string, to_dict, label2index
+
+using MLStyle
+using ..ACSetInterface
+# using Catlab
+# using Catlab.CategoricalAlgebra
+
+@data Args{T} begin
+    Value(T)
+    Kwarg(Symbol, Value{T})
+end
+
+@as_record struct Statement 
+    table::Symbol
+    element::Vector{Args}
+end
+
+@as_record struct ACSetSpec
+    acstype::Union{Symbol, Expr}
+    body::Vector{Statement}
+end
+
+"""    to_string(s::ACSetSpec)
+
+generates a human readable string of the ACSetSpec (or any sub-term).
+"""
+function to_string(s)
+    let ! = to_string
+        @match s begin
+            Value(v)           => string(v)
+            Kwarg(k, v)         => "$k=$(!v)"
+            Statement(t, e)     => "  $t($(join(to_string.(e), ",")))"
+            ACSetSpec(s, body)     => "$s begin \n$(join([!b for b in body], "\n"))\n end"
+        end
+    end
+end
+
+function to_dict(s)
+    let ! = to_dict
+        @match s begin
+            Value(v)             => v
+            Kwarg(k, v)          => Pair(k, v._1)
+            Statement(t, e)      => Dict(:table=>t, :fields => Dict(map(!, e)...))
+            ACSetSpec(s, body)   => Dict(:type=>string(s), :data=>map(!, body))
+            x => error("got input $x")
+        end
+    end
+end
+
+escape_if_symbol(v) = v
+escape_if_symbol(v::Symbol) = QuoteNode(v)
+
+
+"""    generate_expr(s::ACSetSpec)
+
+creates a julia Expr that will generate_expr the specified ACSet. 
+"""
+function generate_expr(e::Args)
+    @match e begin
+        Value(v) =>  escape_if_symbol(v)
+        Kwarg(k, v) => (k=>generate_expr(v))
+    end
+end
+
+function generate_expr(b::Statement)
+    args = generate_expr.(b.element)
+    if eltype(args) <: Pair
+        ex = :(add_part!(X, $(QuoteNode(b.table))))
+        append!(ex.args, map(args) do (k,v)
+            Expr(:kw, k, v)
+        end)
+        return ex
+    else
+        return :(add_part!(X, $(QuoteNode(b.table)), $(args...)))
+    end
+end
+
+function generate_expr(sp::ACSetSpec)
+    body = generate_expr.(sp.body)
+    bexp = :(begin end)
+    push!(bexp.args, body)
+    quote
+        X = $(sp.acstype)()
+        $(body...)
+    end
+end
+
+
+
+function construct!(X, b::Statement)
+    args = map(b.element) do e
+        @match e begin
+            Value(v) => v
+            Kwarg(k,v) => (k=>v._1)
+        end
+    end
+    add_part!(X, b.table; args...)
+end
+
+"""    construct(T::Type, sp::ACSetSpec)
+
+invoke the constructor and build the acset by adding parts.
+"""
+function construct(T::Type, sp::ACSetSpec)
+    X = T()
+    # X = eval(sp.acstype)()
+    map(sp.body) do b
+        construct!(X, b)
+    end
+    return X
+end
+
+find_kwargs(exp) = begin
+    @match exp begin
+        Expr(:call, args...) => map(find_kwargs,args)
+        Expr(:kw, args...) => Kwarg(args[1], Value(args[2]))
+        x::Symbol => x
+        a => error("could not find kwargs or values in $a")
+    end
+end
+
+expand_statement(args) = begin
+    let ! = expand_statement
+        @match args begin
+            as::AbstractVector => map(!, as)
+            Expr(:kw, args...) => Kwarg(args[1], !(args[2]))
+            x => Value(x)
+            x => error("hit fallthrough on $(typeof(x)), $x")
+        end
+    end
+end
+
+"""    acsetspec(head::Symbol, body::Expr)
+
+processes a Julia Expr specifying the ACSet construction into a the ADT representation. Approximate inverse to `to_string`
+"""
+function acsetspec(head, body)
+    processed_body = @match body begin
+        Expr(:block, lines...) => begin
+            map(lines) do line
+                @match line begin
+                    :: LineNumberNode => nothing
+                    Expr(:call, args...) => begin 
+                        pargs = expand_statement(args)
+                        Statement(pargs[1]._1, pargs[2:end])
+                    end
+                    _ => error("all lines must be calls $line")
+                end
+            end
+        end
+        _ => error("expected block")
+    end
+    spec = ACSetSpec(head, filter(!isnothing, processed_body))
+end
+
+function label2index(lt, s)
+    @match s begin
+        vs::Vector => [label2index(lt, v) for v in vs]
+        Statement(t, elts) => Statement(t, map(e->label2index(lt, e), elts))
+        Kwarg(k, v::Value{Symbol}) => Kwarg(k, Value(k!=:label ? lt[v._1] : v._1))
+        Kwarg(k, v) => Kwarg(k, v)
+        x => x
+    end
+end
+
+"""    label2index(s::ACSetSpec)
+
+replace symbolic identifiers in an ACSet spec with the indices that have that label.
+This function assumes that all labels are globally unique across tables. 
+So prefix them with the table name if you want scopes.
+It also assumes that you don't have any other attributes of type symbol, so use strings instead.
+"""
+function label2index(s::ACSetSpec)
+    lookuptable = Dict{Symbol, Int}()
+    map(enumerate(s.body)) do (i,b)
+        @match b begin
+            Statement(t, elts) => map(elts) do e 
+                @match e begin
+                    Kwarg(k, v) => if k == :label
+                        v._1 in keys(lookuptable) && error("Labels are not globally unique")
+                        lookuptable[v._1] = i
+                    end
+                    _ => nothing
+                end
+            end
+            _ => nothing
+        end
+    end
+    newbody = label2index(lookuptable, s.body)
+    ACSetSpec(s.acstype, newbody)
+end
+
+end

--- a/test/ADTs.jl
+++ b/test/ADTs.jl
@@ -1,0 +1,115 @@
+using ACSets
+using ACSets.ADTs
+using MLStyle
+using Catlab
+using Catlab.CategoricalAlgebra
+using Catlab.Graphs
+using Catlab.Graphs.BasicGraphs
+using Test
+
+@testset "Basic Constructions" begin
+s = Statement(:E, [Value(2), Value(3)])
+get_table(s) = @match s begin
+    Statement(t, e) => t
+    _ => nothing
+end
+get_arg1(s) = @match s begin
+    Statement(t, e) => e[1]
+end 
+@test get_table(s) == :E
+@test get_arg1(s) == Value(2)
+gspec = ACSetSpec(
+    :(LabeledGraph{Symbol}),
+    [
+        Statement(:V, [Kwarg(:label, Value(:a))])
+        Statement(:V, [Kwarg(:label, Value(:b))])
+        Statement(:V, [Kwarg(:label, Value(:c))])
+        Statement(:E, [Value(1), Value(3)])
+        Statement(:E, [Value(2), Value(3)])
+    ]
+)
+println(to_string(gspec))
+@show generate_expr(gspec)
+end
+
+
+gspec = ACSetSpec(
+    :(LabeledGraph{Symbol}),
+    [
+        Statement(:V, [Kwarg(:label, Value(:a))])
+        Statement(:V, [Kwarg(:label, Value(:b))])
+        Statement(:V, [Kwarg(:label, Value(:c))])
+        Statement(:E, [Kwarg(:src, Value(1)), Kwarg(:tgt, Value(3))])
+        Statement(:E, [Kwarg(:src, Value(2)), Kwarg(:tgt, Value(3))])
+    ]
+)
+
+@testset "Constructing ACSets from Specs" begin
+    g = construct(LabeledGraph{Symbol}, gspec)
+    @test nparts(g, :V) == 3
+    @test nparts(g, :E) == 2
+end
+
+println("h is ")
+hspec = acsetspec(:(LabeledGraph{Symbol}),quote
+    V(label=a)
+    V(label=b)
+    V(label=c)
+    E(src=1,tgt=3)
+    E(src=2,tgt=3)
+end
+)
+println(hspec)
+println(to_string(hspec))
+@testset "Parsing" begin
+    @test construct(LabeledGraph{Symbol}, hspec) == construct(LabeledGraph{Symbol}, gspec)
+end
+to_string(hspec) |> println
+# cspec = acsetspec(:SemiSimplicialSet,quote
+#     V(label=:a, pos=(0,0))
+#     V(label=:b, pos=(1,0))
+#     V(label=:c, pos=(0,1))
+#     E(1,2)
+#     E(2,3)
+#     E(3,1)
+#     T(1,2,3)
+# end
+# ) |> to_string |> println
+using JSON
+@testset "to_dict" begin
+to_dict(gspec) |> println
+JSON.json(to_dict(gspec))
+#JSON.print(to_dict(gspec), 2)
+end
+
+@testset "Labeled Vertices" begin
+    gspec = ACSetSpec(
+    :(LabeledGraph{Symbol}),
+    [
+        Statement(:V, [Kwarg(:label, Value(:a))])
+        Statement(:V, [Kwarg(:label, Value(:b))])
+        Statement(:V, [Kwarg(:label, Value(:c))])
+        Statement(:E, [Kwarg(:src, Value(:a)), Kwarg(:tgt, Value(:c))])
+        Statement(:E, [Kwarg(:src, Value(:b)), Kwarg(:tgt, Value(:c))])
+    ]
+)
+println(to_string(gspec))
+label2index(gspec) |> to_string |> println
+gl = construct(LabeledGraph{Symbol}, label2index(gspec))
+@test gl[:label] == [:a, :b, :c]
+@test gl[:src] == [1,2]
+@test gl[:tgt] == [3,3]
+
+gspec_bad_labels = ACSetSpec(
+    :(LabeledGraph{Symbol}),
+    [
+        Statement(:V, [Kwarg(:label, Value(:a))])
+        Statement(:V, [Kwarg(:label, Value(:b))])
+        Statement(:V, [Kwarg(:label, Value(:a))])
+        Statement(:E, [Kwarg(:src, Value(:a)), Kwarg(:tgt, Value(:c))])
+        Statement(:E, [Kwarg(:src, Value(:b)), Kwarg(:tgt, Value(:c))])
+    ]
+)
+
+@test_throws ErrorException label2index(gspec_bad_labels)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,3 +24,7 @@ end
 @testset "JSON" begin
   include("JSONACSets.jl")
 end
+
+@testset "ADTs" begin
+  include("ADTs.jl")
+end


### PR DESCRIPTION
This PR is adding support for an ADT based language for writing ACSets. Current blocker is that when I moved the code into the ACSets package, the runtime can't find `add_part!`. Once that is fixed, it should be able to run. Another issue is that the tests rely on Catlab.Graphs for example schemas.