### PR TITLE
Bugfix in dynamic acset serialization + new test

### DIFF
--- a/src/JSONACSets.jl
+++ b/src/JSONACSets.jl
@@ -11,7 +11,7 @@ import Pkg
 import Tables
 
 using ..ACSetInterface, ..Schemas, ..DenseACSets
-using ..DenseACSets: attr_type
+using ..DenseACSets: attr_type, constructor
 using ..ColumnImplementations: AttrVar # TODO: Move this.
 
 # ACSet serialization

--- a/test/JSONACSets.jl
+++ b/test/JSONACSets.jl
@@ -12,7 +12,7 @@ function roundtrip_json_acset(x::T) where T <: ACSet
   mktempdir() do dir
     path = joinpath(dir, "acset.json")
     write_json_acset(x, path)
-    read_json_acset(T, path)
+    read_json_acset(x isa DynamicACSet ? x : T, path)
   end
 end
 
@@ -34,6 +34,13 @@ g = WeightedGraph{Float64}()
 add_parts!(g, :V, 3)
 add_parts!(g, :E, 2, src=[1,2], tgt=[2,3], weight=[0.5,1.5])
 @test roundtrip_json_acset(g) == g
+
+g = DynamicACSet("WG", SchWeightedGraph; type_assignment=Dict(:Weight=>Float64), 
+                 index=[:src,:tgt])
+add_parts!(g, :V, 3)
+add_parts!(g, :E, 2, src=[1,2], tgt=[2,3], weight=[0.5,1.5])
+@test roundtrip_json_acset(g) == g
+
 
 SchLabeledDDS = BasicSchema([:X], [(:Φ,:X,:X)], [:Label], [(:label,:X,:Label)])
 @acset_type LabeledDDS(SchLabeledDDS, index=[:Φ])


### PR DESCRIPTION
A bug for serialization of dynamic acsets is addressed by explicitly importing `constructor` in the JSON serialization file. A test was added to catch things like this in the future.