### PR TITLE
Make 'constructor' a public part of ACSetInterface

### DIFF
--- a/src/ACSetInterface.jl
+++ b/src/ACSetInterface.jl
@@ -3,7 +3,8 @@ export ACSet, acset_schema, acset_name, dom_parts, subpart_type,
   nparts, parts, has_part, has_subpart, subpart, incident,
   add_part!, add_parts!, set_subpart!, set_subparts!, clear_subpart!,
   rem_part!, rem_parts!, cascading_rem_part!, cascading_rem_parts!,
-  copy_parts!, copy_parts_only!, disjoint_union, tables, pretty_tables, @acset
+  copy_parts!, copy_parts_only!, disjoint_union, tables, pretty_tables, 
+  constructor, @acset
 
 using MLStyle: @match
 using StaticArrays: StaticArray
@@ -319,6 +320,11 @@ Base.isempty(X::ACSet) = all(o->nparts(X,o)==0, types(acset_schema(X)))
 Get a named tuple of Tables.jl-compatible tables from an acset
 """
 function tables end
+
+"""
+Get a nullary callable which constructs an (empty) ACSet of the same type
+"""
+function constructor end
 
 # Pretty printing
 #################

--- a/src/DenseACSets.jl
+++ b/src/DenseACSets.jl
@@ -195,7 +195,7 @@ end
 attrtype_type(x::DynamicACSet, D::Symbol) = x.type_assignment[D]
 attr_type(x::DynamicACSet, f::Symbol) = attrtype_type(x,codom(x.schema, f))
 datatypes(x::DynamicACSet) = x.type_assignment
-constructor(X::DynamicACSet) = ()->DynamicACSet(X.name,X.schema,
+ACSetInterface.constructor(X::DynamicACSet) = ()->DynamicACSet(X.name,X.schema,
   type_assignment=X.type_assignment, 
   index=indices(X), unique_index=unique_indices(X))
 
@@ -270,7 +270,7 @@ end
 attrtype_type(::StructACSet{S,Ts}, D::Symbol) where {S,Ts} = attrtype_instantiation(S, Ts, D)
 attr_type(X::StructACSet{S}, f::Symbol) where {S} = attrtype_type(X, codom(S, f))
 datatypes(::StructACSet{S,Ts}) where {S,Ts} = Dict(zip(attrtypes(S),Ts.parameters))
-constructor(X::StructACSet) = typeof(X)
+ACSetInterface.constructor(X::StructACSet) = typeof(X)
 
 function ACSetTableSchema(s::Schema{Symbol}, ob::Symbol)
   attrs = filter(Schemas.attrs(s)) do (f,d,c)

--- a/src/JSONACSets.jl
+++ b/src/JSONACSets.jl
@@ -11,7 +11,7 @@ import Pkg
 import Tables
 
 using ..ACSetInterface, ..Schemas, ..DenseACSets
-using ..DenseACSets: attr_type, constructor
+using ..DenseACSets: attr_type
 using ..ColumnImplementations: AttrVar # TODO: Move this.
 
 # ACSet serialization


### PR DESCRIPTION
`constructor(X::ACSet)` returns a callable which can produce (empty) ACSets of the same type as `X`. This was previously an unexported function in DenseACSets.jl, but this PR makes it publicly exported.