### PR TITLE
Bug fix in `rem_parts!` for attr vars and removing 'free variables'

### DIFF
--- a/src/ACSetInterface.jl
+++ b/src/ACSetInterface.jl
@@ -4,7 +4,7 @@ export ACSet, acset_schema, acset_name, dom_parts, subpart_type,
   add_part!, add_parts!, set_subpart!, set_subparts!, clear_subpart!,
   rem_part!, rem_parts!, cascading_rem_part!, cascading_rem_parts!, gc!,
   copy_parts!, copy_parts_only!, disjoint_union, tables, pretty_tables,
-  @acset, constructor, PartsType, DenseParts, MarkAsDeleted, remove_freevars!
+  @acset, constructor, PartsType, DenseParts, MarkAsDeleted, rem_free_vars!
 
 using MLStyle: @match
 using StaticArrays: StaticArray
@@ -486,13 +486,13 @@ function make_acset end
 """
 Remove all AttrType parts that are not in the image of any of the attributes.
 """
-function remove_freevars!(acs::ACSet)
+function rem_free_vars!(acs::ACSet)
   for k in attrtypes(acset_schema(acs)) 
-    remove_freevars!(acs, k)
+    rem_free_vars!(acs, k)
   end
 end
 
-remove_freevars!(X::ACSet, a::Symbol) = rem_parts!(X, a, filter(parts(X,a)) do p 
+rem_free_vars!(X::ACSet, a::Symbol) = rem_parts!(X, a, filter(parts(X,a)) do p 
   all(f->isempty(incident(X, AttrVar(p), f)), 
       attrs(acset_schema(X); to=a, just_names=true))
 end)

--- a/test/ACSets.jl
+++ b/test/ACSets.jl
@@ -217,9 +217,10 @@ for (dgram_maker, ldgram_maker) in dgram_makers
   set_subpart!(d, 1:3, :parent, 4)
   set_subpart!(d, [4,5], :parent, 5)
 
-  remove_freevars!(d) # now the added X is AttrVar(1), if IntParts
-  A = AttrVar(d.parts[:X] isa IntParts ? 1 : 3)
-
+  rem_free_vars!(d) # now the added X is AttrVar(1), if IntParts
+  @test nparts(d, :R) == 1
+  A = AttrVar(only(parts(d, :R)))
+  
   @test nparts(d, :X) == 5
   @test subpart(d, 1:3, :parent) == [4,4,4]
   @test subpart(d, 4, :parent) == 5

--- a/test/ACSets.jl
+++ b/test/ACSets.jl
@@ -217,6 +217,9 @@ for (dgram_maker, ldgram_maker) in dgram_makers
   set_subpart!(d, 1:3, :parent, 4)
   set_subpart!(d, [4,5], :parent, 5)
 
+  remove_freevars!(d) # now the added X is AttrVar(1), if IntParts
+  A = AttrVar(d.parts[:X] isa IntParts ? 1 : 3)
+
   @test nparts(d, :X) == 5
   @test subpart(d, 1:3, :parent) == [4,4,4]
   @test subpart(d, 4, :parent) == 5
@@ -226,7 +229,7 @@ for (dgram_maker, ldgram_maker) in dgram_makers
   @test has_subpart(d, :height)
   @test subpart(d, [1,2,3], :height) == [0,0,0]
   @test subpart(d, 4, :height) == 10
-  @test subpart(d, :, :height) == [0,0,0,10,AttrVar(3)]
+  @test subpart(d, :, :height) == [0,0,0,10,A]
 
   # Chained accessors.
   @test subpart(d, 3, [:parent, :parent]) == 5
@@ -237,7 +240,7 @@ for (dgram_maker, ldgram_maker) in dgram_makers
   # Indexing syntax.
   @test d[3, :parent] == 4
   @test d[3, [:parent, :height]] == 10
-  @test d[3:5, [:parent, :height]] == [10,AttrVar(3),AttrVar(3)]
+  @test d[3:5, [:parent, :height]] == [10,A,A]
   @test d[:, :parent] == [4,4,4,5,5]
   d2 = copy(d)
   d2[1, :parent] = 1
@@ -248,7 +251,7 @@ for (dgram_maker, ldgram_maker) in dgram_makers
 
   # Copying parts.
   d2 = dgram_maker(Int)
-  copy_parts!(d2, d, X=[4,5], R=[3])
+  copy_parts!(d2, d, X=[4,5], R=[A.val])
   @test nparts(d2, :X) == 2
   @test subpart(d2, [1,2], :parent) == [2,2]
   @test subpart(d2, [1,2], :height) == [10, AttrVar(1)]
@@ -256,7 +259,7 @@ for (dgram_maker, ldgram_maker) in dgram_makers
   du = disjoint_union(d, d2)
   @test nparts(du, :X) == 7
   @test subpart(du, :parent) == [4,4,4,5,5,7,7]
-  @test subpart(du, :height) == [0,0,0,10,AttrVar(3),10,AttrVar(4)]
+  @test subpart(du, :height) == [0,0,0,10,A,10,AttrVar(A.val+1)]
 
   # Pretty printing of data attributes.
   s = sprint(show, d)
@@ -296,7 +299,10 @@ for (dgram_maker, ldgram_maker) in dgram_makers
   @test subpart(ld, :leafparent) == [2,3,4]
   d′ = dgram_maker(Int)
   copy_parts!(d′, ld)
-  @test d′ == d
+
+  @test d′[:parent] == d[:parent]
+  @test d[:height] == [0,0,0,10,A]
+  @test d′[:height] == [0,0,0,10,AttrVar(1)]
 end
 
 # Subsets


### PR DESCRIPTION
This addresses https://github.com/AlgebraicJulia/ACSets.jl/issues/48.

There are some changes in the tests required because, now that AttrVar indices change depending on whether we are using dense vs MAD acsets, the same equality tests will not work for both cases.