### PR TITLE
Don't export `generators` function

### DIFF
--- a/src/NautyInterface.jl
+++ b/src/NautyInterface.jl
@@ -1,7 +1,7 @@
 """Compute automorphism group via nauty.c"""
 module NautyInterface
 export NautyRes, CSetNautyRes, call_nauty, all_autos, canon, orbits, canonmap, 
-       strhsh, generators, ngroup
+       strhsh, ngroup
 
 using ..Schemas
 using ..DenseACSets, ..ACSetInterface

--- a/test/NautyInterface.jl
+++ b/test/NautyInterface.jl
@@ -4,7 +4,7 @@ using Test
 using ACSets
 using Permutations
 using nauty_jll
-using ACSets.NautyInterface: _all_autos
+using ACSets.NautyInterface: _all_autos, generators
 
 # Helper functions
 ##################


### PR DESCRIPTION
Catlab also defines `generators` but isn't in a position right now to make a new release, so temporarily we will not export this to avoid creating an ambiguous name.