### PR TITLE
Produce JSONSchema from an InterType Module

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 ACSets = "227ef7b5-1206-438b-ac65-934d6da304b8"
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 JSONSchema = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
 MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"

--- a/test/intertypes/InterTypes.jl
+++ b/test/intertypes/InterTypes.jl
@@ -4,7 +4,9 @@ using ACSets
 using ACSets.InterTypes
 using Test
 using OrderedCollections
+import JSON
 import JSON3
+import JSONSchema
 
 function testjson(x::T) where {T}
   (x == jsonread(jsonwrite(x), T))
@@ -41,6 +43,12 @@ s = jsonwrite(t)
 
 @test jsonread(s, Term) == t
 
+generate_jsonschema_module(simpleast, ".")
+
+simpleast_schema = JSONSchema.Schema(read("simpleast_schema.json", String))
+
+@test JSONSchema._validate(simpleast_schema, JSON.parse(s), "Term") === nothing
+
 @intertypes "model.it" module model
   import ..simpleast
 end
@@ -62,6 +70,12 @@ add_parts!(g, :V, 2)
 add_part!(g, :E, src=1, tgt=2, weight=EdgeData(:mass_ave, 42))
 
 @test testjson(m)
+
+generate_jsonschema_module(wgraph, ".")
+
+wgraph_schema = JSONSchema.Schema(read("wgraph_schema.json", String))
+
+@test JSONSchema._validate(wgraph_schema, JSON.parse(jsonwrite(g)), "EDWeightedGraph") === nothing
 
 @static if !Sys.iswindows()
   using CondaPkg


### PR DESCRIPTION
This was already support for non-acsets, this PR adds support for acsets and also tests validation of produced JSON agains this in CI.