### PR TITLE
Check for nonexistent names in acset macro

### DIFF
--- a/src/DenseACSets.jl
+++ b/src/DenseACSets.jl
@@ -988,6 +988,11 @@ Tables.columnnames(row::ACSetRow) = Base.propertynames(row)
     s = Schema(S)
   end
   acs = T()
+  @ct begin
+    for n in names
+      (n ∈ types(s) || n ∈ arrows(s; just_names=true)) || error("$(n) is not defined in schema")
+    end
+  end 
   @ct_ctrl for ob in intersect(types(s), names)
     add_parts!(acs, @ct(ob), rows[@ct ob])
   end

--- a/test/ACSets.jl
+++ b/test/ACSets.jl
@@ -530,6 +530,13 @@ l = @acset DecGraph{String} begin
   dec = ["a","a"]
 end
 
+# errors when user inputs nonexistent names
+@test_throws Exception @acset DDS begin
+  W=3
+  Φ=[1,2,3]
+end
+
+
 # Test mapping
 #-------------
 


### PR DESCRIPTION
Addresses #55; this exact issue recently came up when introducing a new user to acsets, so it seemed timely to address.