### PR TITLE
`rem_parts!` and `cascading_rem_parts!` can take colon arg

### DIFF
--- a/src/ACSetInterface.jl
+++ b/src/ACSetInterface.jl
@@ -350,6 +350,10 @@ See also: [`rem_part!`](@ref).
   end
 end
 
+@inline function rem_parts!(acs::ACSet, type, ::Colon)
+  rem_parts!(acs, type, parts(acs, type))
+end
+
 """ Remove parts and all parts incident to them, recursively.
 
 The parts may be supplied in any order and may include duplicates.

--- a/src/DenseACSets.jl
+++ b/src/DenseACSets.jl
@@ -708,6 +708,9 @@ function delete_subobj!(X::ACSet, delparts)
   end)
 end
 
+ACSetInterface.cascading_rem_parts!(acs::ACSet, type, ::Colon) =
+  cascading_rem_parts!(acs, type, parts(acs, type))
+
 ACSetInterface.cascading_rem_parts!(acs::ACSet, type, parts) =
   delete_subobj!(acs, Dict(type=>parts))
 

--- a/test/ACSets.jl
+++ b/test/ACSets.jl
@@ -137,6 +137,12 @@ for dds_maker in dds_makers
     @test incident(dds, 2, :Φ) == []
   end
 
+  # delete all parts of an Ob
+  dds = dds_maker()
+  add_parts!(dds, :X, 4, Φ=[2,3,3,4])
+  rem_parts!(dds, :X, :)
+  @test nparts(dds, :X) == 0
+
   # Recursive deletion.
   dds = dds_maker()
   add_parts!(dds, :X, 3, Φ=[2,3,3])
@@ -147,6 +153,11 @@ for dds_maker in dds_makers
   add_parts!(dds, :X, 3, Φ=[2,3,3])
   cascading_rem_parts!(dds, :X, [1,2])
   @test nparts(dds, :X) == 1
+
+  dds = dds_maker()
+  add_parts!(dds, :X, 3, Φ=[2,3,3])
+  cascading_rem_parts!(dds, :X, :)
+  @test nparts(dds, :X) == 0
 
   # Pretty printing.
   dds = dds_maker()


### PR DESCRIPTION
Address #116, it's handy to be able to remove all parts of an Ob with a `:`, which is similar to how the `:` works in other interface functions in the package.