### PR TITLE
Remove stale method for `subpart`

### DIFF
--- a/src/ACSetInterface.jl
+++ b/src/ACSetInterface.jl
@@ -159,8 +159,6 @@ they have different domains (belong to different tables).
 """
 function subpart end
 
-@inline Base.@propagate_inbounds subpart(acs, part, name) = view_or_slice(subpart(acs, name), part)
-
 function view_or_slice end
 @inline view_or_slice(x::AbstractVector, i::Union{Integer,StaticArray}) = x[i]
 @inline view_or_slice(x::AbstractVector, ::Colon) = x


### PR DESCRIPTION
Not only is this method apparently not being used, its behavior is incompatible with the new intended behavior in #36.

CC @kris-brown 