### PR TITLE
Remove `collect_or_id` in subpart accessor

### DIFF
--- a/src/ACSetInterface.jl
+++ b/src/ACSetInterface.jl
@@ -164,12 +164,9 @@ function view_or_slice end
 @inline view_or_slice(x::AbstractVector, ::Colon) = x
 @inline Base.@propagate_inbounds view_or_slice(x::AbstractVector, i) = @view x[i]
 
-collect_or_id(i) = i
-collect_or_id(xs::AbstractVector{T}) where {T} = T[xs...]
-
 function subpart(acs, part, names::AbstractVector{Symbol})
   foldl(names, init=part) do part, name
-    collect_or_id(subpart(acs, part, name))
+    subpart(acs, part, name)
   end
 end
 

--- a/src/DenseACSets.jl
+++ b/src/DenseACSets.jl
@@ -529,14 +529,14 @@ ACSetInterface.subpart(acs::DynamicACSet, part, names::Tuple{Vararg{Symbol}}) = 
 
 @ct_enable function _subpart(acs::SimpleACSet, part, @ct(S), @ct(names))
   @ct s = Schema(S)
-  out = ACSetInterface.collect_or_id(subpart(acs, part, @ct first(names)))
+  out = subpart(acs, part, @ct first(names))
   # necessary because Tuple{Symbol} is still ambigious with presence of Tuple{Vararg{Symbol}}
   @ct_ctrl if length(names) > 1
     @ct_ctrl for i in 2:length(names)
       @ct begin
         codom(s, names[i-1]) == dom(s, names[i]) || error("morphisms $(names[i-1]) and $(names[i]) are not composable")
       end
-      out = ACSetInterface.collect_or_id(subpart(acs, out, @ct names[i]))
+      out = subpart(acs, out, @ct names[i])
     end
   end
   return out


### PR DESCRIPTION
Addresses https://github.com/AlgebraicJulia/ACSets.jl/issues/128 by removing unnecessary calls to `collect`. 

It turns out the function was unnecessary - https://github.com/AlgebraicJulia/ACSets.jl/pull/36 introduced the`collect_column` which is sufficient for making sure that `X[:f]` returns a mutable vector copy rather than access to the direct underlying column.

(I'll be testing that this doesn't break downstream packages in the near future)