### PR TITLE
Switch to ARM architecture for Mac tests

### DIFF
--- a/.github/workflows/julia_ci.yml
+++ b/.github/workflows/julia_ci.yml
@@ -49,7 +49,7 @@ jobs:
         include:
           # test macOS and Windows with latest Julia only
           - os: macOS-latest
-            arch: x64
+            arch: arm64
             version:  "1.10.0" 
           - os: windows-latest
             arch: x64


### PR DESCRIPTION
Tests for the InterTypes Java integration are failing due to an architecture mismatch.