### PR TITLE
Reduce allocations in vectorized operations

### DIFF
--- a/src/ACSetInterface.jl
+++ b/src/ACSetInterface.jl
@@ -5,8 +5,7 @@ export ACSet, acset_schema, acset_name, dom_parts, codom_parts, subpart_type,
   rem_part!, rem_parts!, cascading_rem_part!, cascading_rem_parts!, gc!,
   copy_parts!, copy_parts_only!, disjoint_union, tables, pretty_tables,
   @acset, constructor, undefined_subparts, PartsType, DenseParts, MarkAsDeleted,
-  rem_free_vars!, parts_type,
-  ACSetAllocTest
+  rem_free_vars!, parts_type
 
 using MLStyle: @match
 using StaticArrays: StaticArray
@@ -261,18 +260,20 @@ function set_subpart! end
   set_subpart!(acs, 1:length(subpart(acs,name)), name, vals)
 
 # Inlined for the same reason as `subpart`.
-
-@inline function set_subpart!(acs::ACSet , parts::Union{AbstractVector{Int}, AbstractSet{Int}}, name, vals)
-  broadcast(parts, vals) do part, val
-    set_subpart!(acs, part, name, val)
-  end
-end
+@inline set_subpart!(acs::ACSet , parts::Union{AbstractVector{Int}, AbstractSet{Int}}, name, vals) = 
+  set_subpart!(acs , parts, Val{name}, vals)
 
 @inline function set_subpart!(acs::ACSet , parts::Union{AbstractVector{Int}, AbstractSet{Int}}, ::Type{Val{name}}, vals) where name
   broadcast(parts, vals) do part, val
     set_subpart!(acs, part, name, val)
   end
 end
+
+# @inline function set_subpart!(acs::ACSet , parts::Union{AbstractVector{Int}, AbstractSet{Int}}, ::Type{Val{name}}, vals) where name
+#   broadcast(parts, vals) do part, val
+#     set_subpart!(acs, part, name, val)
+#   end
+# end
 
 
 """ Mutate subparts of a part in a C-set.
@@ -287,8 +288,7 @@ end
 
 @inline set_subparts!(acs, part; kw...) = set_subparts!(acs, part, (;kw...))
 
-struct ACSetAllocTest end
-@inline Base.setindex!(acs::ACSet, val, part, name, ::ACSetAllocTest) = set_subpart!(acs, part, Val{name}, val)
+# @inline Base.setindex!(acs::ACSet, val, part, name, ::ACSetAllocTest) = set_subpart!(acs, part, Val{name}, val)
 
 @inline Base.setindex!(acs::ACSet, val, part, name) = set_subpart!(acs, part, name, val)
 @inline Base.setindex!(acs::ACSet, vals, name) = set_subpart!(acs, name, vals)

--- a/src/ACSetInterface.jl
+++ b/src/ACSetInterface.jl
@@ -269,13 +269,6 @@ function set_subpart! end
   end
 end
 
-# @inline function set_subpart!(acs::ACSet , parts::Union{AbstractVector{Int}, AbstractSet{Int}}, ::Type{Val{name}}, vals) where name
-#   broadcast(parts, vals) do part, val
-#     set_subpart!(acs, part, name, val)
-#   end
-# end
-
-
 """ Mutate subparts of a part in a C-set.
 
 Both single and vectorized assignment are supported.
@@ -287,8 +280,6 @@ See also: [`set_subpart!`](@ref).
 end
 
 @inline set_subparts!(acs, part; kw...) = set_subparts!(acs, part, (;kw...))
-
-# @inline Base.setindex!(acs::ACSet, val, part, name, ::ACSetAllocTest) = set_subpart!(acs, part, Val{name}, val)
 
 @inline Base.setindex!(acs::ACSet, val, part, name) = set_subpart!(acs, part, name, val)
 @inline Base.setindex!(acs::ACSet, vals, name) = set_subpart!(acs, name, vals)

--- a/src/ACSetInterface.jl
+++ b/src/ACSetInterface.jl
@@ -5,7 +5,8 @@ export ACSet, acset_schema, acset_name, dom_parts, codom_parts, subpart_type,
   rem_part!, rem_parts!, cascading_rem_part!, cascading_rem_parts!, gc!,
   copy_parts!, copy_parts_only!, disjoint_union, tables, pretty_tables,
   @acset, constructor, undefined_subparts, PartsType, DenseParts, MarkAsDeleted,
-  rem_free_vars!, parts_type
+  rem_free_vars!, parts_type,
+  ACSetAllocTest
 
 using MLStyle: @match
 using StaticArrays: StaticArray
@@ -267,6 +268,13 @@ function set_subpart! end
   end
 end
 
+@inline function set_subpart!(acs::ACSet , parts::Union{AbstractVector{Int}, AbstractSet{Int}}, ::Type{Val{name}}, vals) where name
+  broadcast(parts, vals) do part, val
+    set_subpart!(acs, part, name, val)
+  end
+end
+
+
 """ Mutate subparts of a part in a C-set.
 
 Both single and vectorized assignment are supported.
@@ -278,6 +286,9 @@ See also: [`set_subpart!`](@ref).
 end
 
 @inline set_subparts!(acs, part; kw...) = set_subparts!(acs, part, (;kw...))
+
+struct ACSetAllocTest end
+@inline Base.setindex!(acs::ACSet, val, part, name, ::ACSetAllocTest) = set_subpart!(acs, part, Val{name}, val)
 
 @inline Base.setindex!(acs::ACSet, val, part, name) = set_subpart!(acs, part, name, val)
 @inline Base.setindex!(acs::ACSet, vals, name) = set_subpart!(acs, name, vals)

--- a/test/ACSets.jl
+++ b/test/ACSets.jl
@@ -886,4 +886,21 @@ let s = InferenceTest()
   @test iszero(@allocated call_getindex(s))
 end
 
+let s = InferenceTest()
+  N = 5
+  entry = [i for i in 1:N]
+  add_parts!(s, :V, N)
+  @allocated add_parts!(s, :E, N, v0 = entry)
+  call_setrange_single(s) = s[1:N, :v0] = 1
+  call_setrange_entry(s) = s[1:N, :v0] = entry
+
+  call_setrange_single(s)
+  @test s[:v0] == ones(N)
+  @test (@allocated call_setrange_single(s)) < 900
+
+  call_setrange_entry(s)
+  @test s[:v0] == entry
+  @test (@allocated call_setrange_entry(s)) < 900
+end
+
 end # module


### PR DESCRIPTION
This PR is meant as a quick fix for issue #135. It is a non-breaking fix as I've run the tests locally and all have passed. As of writing this I have not yet looked at vectorized gets or using the colon and these might still be issues. 

New benchmarks from initial example: https://github.com/AlgebraicJulia/ACSets.jl/issues/135#issue-2306532997
```julia
[ Info: Using add_vector
  0.000010 seconds (1 allocation: 144 bytes)

[ Info: Using add_loop
  0.000006 seconds
```

So using the vectorized setting now seems to be much improved. There is the issue that there are still some allocations but this is much improved.

Benchmarks run mirroring this later example: https://github.com/AlgebraicJulia/ACSets.jl/issues/135#issuecomment-2123049737
```julia
using ACSets

SchTest = BasicSchema([:V,:E], [(:v0,:E,:V)])

@acset_type Test(SchTest, index=[:v0])

s = Test()

N = 100
add_parts!(s, :V, N)
idx = add_parts!(s, :E, N)

entry = ones(Int64, N);

function add_broadcast(s, idx, entry, symbol)
  broadcast(idx, entry) do i, id
    set_subpart!(s, i, symbol, id)
  end
end

function add_vector(s, idx, symbol, entry)
  s[idx, symbol] = entry
end

function add_subpart_reg(s, idx, symbol, entry)
  set_subpart!(s, idx, symbol, entry)
end

function add_subpart_val(s, idx, symbol, entry)
  set_subpart!(s, idx, Val{symbol}, entry)
end

begin
  add_broadcast(s, idx, entry, :v0)
  add_vector(s, idx, :v0, entry)
  add_subpart_reg(s, idx, :v0, entry)
  add_subpart_val(s, idx, :v0, entry)
end;

@info "Using add_broadcast"
@time add_broadcast(s, idx, entry, :v0);

@info "Using add_vector"
@time add_vector(s, idx, :v0, entry);

@info "Using add_subpart_reg"
@time add_subpart_reg(s, idx, :v0, entry);

@info "Using add_subpart_val"
@time add_subpart_val(s, idx, :v0, entry);

```

```julia
[ Info: Using add_broadcast
  0.000055 seconds (108 allocations: 7.547 KiB)

[ Info: Using add_vector
  0.000021 seconds (4 allocations: 1.031 KiB)

[ Info: Using add_subpart_reg
  0.000121 seconds (4 allocations: 1.031 KiB)

[ Info: Using add_subpart_val
  0.000022 seconds (4 allocations: 1.031 KiB)
```
These show that using either ```set_subparts!``` or the regular setting operator carry the benefits while the old version of broadcast is used to show the original allocations.

