### PR TITLE
Generating optimized chained subparts

### DIFF
--- a/test/ACSets.jl
+++ b/test/ACSets.jl
@@ -797,6 +797,20 @@ datcompdyn = DynamicACSet(datcomp)
 @test subpart(datcompdyn, :, (:f,)) == [1,2,3,1,2]
 @test subpart(datcompdyn, (:f,)) == [1,2,3,1,2]
 
+# Allocations of composites of subparts
+#------------------------------------
+# If type inference is successful, then this loop will be optimized to have 0 allocations.
+buffer = Vector{Symbol}(undef, nparts(datcomp, :Z))
+function assignment_loop!(buffer::Vector{Symbol}, dc::SimpleACSet)
+  @inbounds for i in parts(dc, :Z)
+    buffer[i] = subpart(dc, i, Val((:zattr,)))
+  end
+end
+@allocations assignment_loop!(buffer, datcomp)
+allocs = @allocations assignment_loop!(buffer, datcomp)
+@test allocs == 0
+
+
 # Composites of subparts for incident
 #------------------------------------
 


### PR DESCRIPTION
Close #137 

I did some exploring around the chained subparts issue. There are a few design decisions/ features that came up that are worth exploring:

1. Type inference was previously broken as demonstrated in the linked issue. This branch (currently) fixes that issue by always `@generate`-ing the chained subparts function.
2. The validation code was intertwined with the accessing code. I believe that this impedes getting a function that can be optimized to have no allocations.
3. The validation code only returns the first mismatched `dom` and `codom` pair. It would be something of a mini-feature to return all mismatched pairs instead of just the first one found.
4. It would be nice to have a version of the chained subparts function that does the validation checking and accessing, and one that does not have the validation overhead. This branch (currently) fixes that issue by always validating when given the `(:src,)` syntax, and never validating when given a `Val((:src,))`. It would be nice to split the difference by only checking this at compile time, and guaranteeing that only valid chained subparts functions are generated. I'm not sure if the original CompTime implementation was supposed to guarantee this or not.

With the way that this function is written, the `Expr` for a chained subparts function is returned. This has higher overhead of course that the expression that is just built up from a native `foldl`. I can add this feature in before this PR would be merged.

This PR unfortunately did away with the use of CompTime.jl. I believe that this library could assist with points 3 and 4, but I am not sure how to go about doing that at this moment.