### PR TITLE
Render API Reference page

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,5 +1,20 @@
 # Library Reference
 
 ```@autodocs
-Modules = [ACSets]
+Modules = [
+  ACSetInterface,
+  ACSetSerialization,
+  ACSets,
+  ACSets.ColumnImplementations,
+  ACSets.Columns,
+  ACSets.Defaults,
+  DenseACSets,
+  ExcelACSets,
+  ACSets.IndexUtils,
+  InterTypes,
+  JSONACSets,
+  ACSets.Mappings,
+  NautyInterface,
+  ACSets.PreimageCaches,
+  Schemas]
 ```

--- a/src/ACSetInterface.jl
+++ b/src/ACSetInterface.jl
@@ -400,7 +400,7 @@ function tables end
 """
 Garbage collect in an acset.
 
-For some choices of [`IDAllocator`](@ref), this function is a no-op.
+For some choices of [`PartsType`](@ref), this function is a no-op.
 """
 function gc! end
 

--- a/src/Defaults.jl
+++ b/src/Defaults.jl
@@ -3,7 +3,7 @@ export Default, default, isdefault, DefaultVal, DefaultEmpty
 
 """
 This is a hack in order to pass in a default initializer for
-[`DefaultVecMap`](@ref) as a type parameter
+`DefaultVecMap` as a type parameter
 """
 abstract type Default end
 

--- a/src/intertypes/InterTypes.jl
+++ b/src/intertypes/InterTypes.jl
@@ -11,7 +11,7 @@ import ..Schemas: toexpr
 #######################
 
 """
-A field of a struct. Used in [`Variant`](@ref) and [`Record`](@ref).
+A field of a struct. Used in [`Variant`](@ref) and `Record`.
 
 The `T` parameter will always be [`InterType`](@ref), but this is mutually-recursive
 with `InterType` so we have to be generic here.


### PR DESCRIPTION
Close #139 

In this PR, I tried to resolve the referenced issue by explicitly listing all modules and submodules.

Someone should double check that all the modules that we want to include in the docs page are included. (And only those modules we want included.)

I replaced the reference to `IDAllocator` with one to `PartsType`.

Further, I cannot render the docs locally due to the following issues that I cannot resolve myself due to lack of familiarity with the internals :
- `DefaultVecMap` has no docstring. (This may be referring to a different type now?)
- `Record` has no docstring. (Is it possible to add a docstring for the field of a struct?)
I temporarily resolved those two bullets by removing the ref in both cases.

I did not review any docstrings aside from those causing those immediate errors.

This is about as far as I can take this issue to being closed. But let me know if there are any commits I can take care of. Thanks!