### PR TITLE
Declare `Meta` before using it in `@intertypes`

### DIFF
--- a/src/intertypes/julia.jl
+++ b/src/intertypes/julia.jl
@@ -379,6 +379,7 @@ macro intertypes(file, modexpr)
     end
     _ => error("expected a module expression, got $modexpr")
   end
+  push!(modexpr.args[3].args, :(global Meta))
   imports = Expr(:vect, [:($(Expr(:quote, name)) => $name.Meta) for name in imports]...)
   Expr(
     :toplevel,


### PR DESCRIPTION
The `@intertypes` macro assigns `mod.Meta` without declaring it. This was accidentally allowed in Julia 1.9/1.10 due to a dropped error check, but will likely be disallowed again in Julia 1.11. See https://github.com/JuliaLang/julia/pull/54678.

This just declares it `global` (which is what happened implicitly on Julia 1.10/1.11). That said, you may want a `Const` instead, in which case you would need a different fix.