### PR TITLE
Add equations to schemas

### DIFF
--- a/.buildkite/jobscript.sh
+++ b/.buildkite/jobscript.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+pwd; hostname; date
+
+module load julia
+
+echo "Running Tests..."
+julia --project -e 'using Pkg; Pkg.status(); Pkg.test()'
+
+echo "Building Documentation..."
+julia -t 16 --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.status(); Pkg.instantiate(); include("docs/make.jl")'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,20 @@
+env:
+  JULIA_VERSION: "1.10.2"
+
+steps:
+
+  - label: ":hammer: Build Project"
+    command: 
+      - "module load julia"
+      - "julia --project=docs --color=yes -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.precompile()'"
+         
+  - wait 
+
+  - label: ":scroll: Build docs and run tests"
+    command:
+      - "srun --cpus-per-task=16 --mem=8G --time=1:00:00 --output=.buildkite/build_%j.log --unbuffered .buildkite/jobscript.sh"
+    env:
+      JULIA_PROJECT: "docs/"
+
+  - wait
+

--- a/Project.toml
+++ b/Project.toml
@@ -32,7 +32,7 @@ NautyACSetsExt = "nauty_jll"
 XLSXACSetsExt = "XLSX"
 
 [compat]
-AlgebraicInterfaces = "0.1"
+AlgebraicInterfaces = "0.1.3"
 Base64 = "1.9"
 CompTime = "0.1"
 DataStructures = "0.18"

--- a/src/DenseACSets.jl
+++ b/src/DenseACSets.jl
@@ -401,7 +401,7 @@ function ACSetTableSchema(s::Schema{Symbol}, ob::Symbol)
   attrs = filter(Schemas.attrs(s)) do (f,d,c)
     d == ob
   end
-  BasicSchema{Symbol}([ob], [], attrtypes(s), attrs)
+  BasicSchema{Symbol}([ob], [], attrtypes(s), attrs, [])
 end
 
 function ACSetTableDataType(::Type{<:StructACSet{S,Ts}}, ob::Symbol) where {S,Ts}

--- a/src/Schemas.jl
+++ b/src/Schemas.jl
@@ -116,21 +116,27 @@ abstract type TypeLevelBasicSchema{Name, obs, homs, attrtypes, attrs, eqs} <: Ty
 
 const TypeLevelBasicCSetSchema{Name, obs, homs} = TypeLevelBasicSchema{Name, obs, homs, Tuple{}, Tuple{}, Tuple{}}
 
+# A path has sequence of hom/attr names
+const Pth{Name}= Tuple{Vararg{Name}}
+
+# An Eq has an optional name, a dom, a codom, and pair of paths
+const Eq{Name} = Tuple{Union{Nothing, Name}, Name, Name, Tuple{Pth{Name},Pth{Name}}}
+
 @struct_hash_equal struct BasicSchema{Name} <: Schema{Name}
   obs::Vector{Name}
   homs::Vector{Tuple{Name,Name,Name}}
   attrtypes::Vector{Name}
   attrs::Vector{Tuple{Name,Name,Name}}
-  eqs::Vector{Tuple{Union{Nothing, Name}, Name, Name, Tuple{Vararg{Tuple{Vararg{Name}}}}}}
+  eqs::Vector{Eq{Name}}
   function BasicSchema{Name}(obs, homs, attrtypes, attrs, eqs) where {Name}
     new{Name}(obs, homs, attrtypes, attrs, eqs)
   end
   function BasicSchema(obs::Vector{Name}, homs, attrtypes, attrs, eqs=nothing) where {Name}
-    eqs = isnothing(eqs) ? Tuple{Name, Name, Name, Tuple{Vararg{Tuple{Vararg{Name}}}}}[] : eqs
+    eqs = isnothing(eqs) ? Eq{Name}[] : eqs
     new{Name}(obs, homs, attrtypes, attrs, eqs)
   end
   function BasicSchema(obs::Vector{Name}, homs, eqs=nothing) where {Name}
-    eqs = isnothing(eqs) ? Tuple{Name, Name, Name, Tuple{Vararg{Tuple{Vararg{Name}}}}}[] : eqs
+    eqs = isnothing(eqs) ? Eq{Name}[] : eqs
     new{Name}(obs, homs, Name[], Tuple{Name,Name,Name}[], eqs)
   end
   function BasicSchema{Name}() where {Name}
@@ -139,7 +145,7 @@ const TypeLevelBasicCSetSchema{Name, obs, homs} = TypeLevelBasicSchema{Name, obs
       Vector{Tuple{Name,Name,Name}}(),
       Vector{Name}(),
       Vector{Tuple{Name,Name,Name}}(),
-      Vector{Tuple{Union{Nothing, Name}, Name, Name, Vector{Vector{Name}}}}()
+      Vector{Eq{Name}}()
     )
   end
 end

--- a/src/Schemas.jl
+++ b/src/Schemas.jl
@@ -121,16 +121,16 @@ const TypeLevelBasicCSetSchema{Name, obs, homs} = TypeLevelBasicSchema{Name, obs
   homs::Vector{Tuple{Name,Name,Name}}
   attrtypes::Vector{Name}
   attrs::Vector{Tuple{Name,Name,Name}}
-  eqs::Vector{Tuple{Name, Name, Tuple{Vararg{Tuple{Vararg{Name}}}}}}
+  eqs::Vector{Tuple{Union{Nothing, Name}, Name, Name, Tuple{Vararg{Tuple{Vararg{Name}}}}}}
   function BasicSchema{Name}(obs, homs, attrtypes, attrs, eqs) where {Name}
     new{Name}(obs, homs, attrtypes, attrs, eqs)
   end
   function BasicSchema(obs::Vector{Name}, homs, attrtypes, attrs, eqs=nothing) where {Name}
-    eqs = isnothing(eqs) ? Tuple{Name, Name, Tuple{Vararg{Tuple{Vararg{Name}}}}}[] : eqs
+    eqs = isnothing(eqs) ? Tuple{Name, Name, Name, Tuple{Vararg{Tuple{Vararg{Name}}}}}[] : eqs
     new{Name}(obs, homs, attrtypes, attrs, eqs)
   end
   function BasicSchema(obs::Vector{Name}, homs, eqs=nothing) where {Name}
-    eqs = isnothing(eqs) ? Tuple{Name, Name, Tuple{Vararg{Tuple{Vararg{Name}}}}}[] : eqs
+    eqs = isnothing(eqs) ? Tuple{Name, Name, Name, Tuple{Vararg{Tuple{Vararg{Name}}}}}[] : eqs
     new{Name}(obs, homs, Name[], Tuple{Name,Name,Name}[], eqs)
   end
   function BasicSchema{Name}() where {Name}
@@ -139,7 +139,7 @@ const TypeLevelBasicCSetSchema{Name, obs, homs} = TypeLevelBasicSchema{Name, obs
       Vector{Tuple{Name,Name,Name}}(),
       Vector{Name}(),
       Vector{Tuple{Name,Name,Name}}(),
-      Vector{Tuple{Name, Name, Vector{Vector{Name}}}}()
+      Vector{Tuple{Union{Nothing, Name}, Name, Name, Vector{Vector{Name}}}}()
     )
   end
 end

--- a/src/serialization/JSONACSets.jl
+++ b/src/serialization/JSONACSets.jl
@@ -133,6 +133,11 @@ function generate_json_acset_schema(schema::Schema)
     "Attr" => map(attrs(schema)) do (f, x, y)
       Dict("name" => string(f), "dom" => string(x), "codom" => string(y))
     end,
+    "equations" => map(equations(schema)) do (x, y, eqs)
+      Dict("dom" => string(x), "codom" => string(y), 
+           "paths" => [string.(eq) for eq in collect.(eqs)], )
+    end,
+
   )
 end
 
@@ -152,7 +157,12 @@ function parse_json_acset_schema(::Type{BasicSchema}, data::AbstractDict)
   attrs = map(data["Attr"]) do d
     map(Symbol, (d["name"], d["dom"], d["codom"]))
   end
-  BasicSchema(obs, homs, attrtypes, attrs)
+  eqs = map(data[:equations]) do d 
+    (Symbol(d["dom"]), Symbol(d["codom"]), tuple(map(d["paths"]) do p
+      tuple(Symbol.(p)...)
+    end...))
+  end
+  BasicSchema(obs, homs, attrtypes, attrs, eqs)
 end
 
 function parse_json_acset_schema(T, input::AbstractString)

--- a/src/serialization/JSONACSets.jl
+++ b/src/serialization/JSONACSets.jl
@@ -133,8 +133,9 @@ function generate_json_acset_schema(schema::Schema)
     "Attr" => map(attrs(schema)) do (f, x, y)
       Dict("name" => string(f), "dom" => string(x), "codom" => string(y))
     end,
-    "equations" => map(equations(schema)) do (x, y, eqs)
+    "equations" => map(equations(schema)) do (n, x, y, eqs)
       Dict("dom" => string(x), "codom" => string(y), 
+           "name" => isnothing(n) ? n : string(n),
            "paths" => [string.(eq) for eq in collect.(eqs)], )
     end,
 
@@ -158,7 +159,8 @@ function parse_json_acset_schema(::Type{BasicSchema}, data::AbstractDict)
     map(Symbol, (d["name"], d["dom"], d["codom"]))
   end
   eqs = map(data[:equations]) do d 
-    (Symbol(d["dom"]), Symbol(d["codom"]), tuple(map(d["paths"]) do p
+    name = isnothing(d["name"]) ? nothing : Symbol(d["name"])
+    (name, Symbol(d["dom"]), Symbol(d["codom"]), tuple(map(d["paths"]) do p
       tuple(Symbol.(p)...)
     end...))
   end

--- a/test/Schemas.jl
+++ b/test/Schemas.jl
@@ -4,7 +4,7 @@ using Test
 using ACSets.Schemas
 
 bsch = BasicSchema([:E,:V], [(:src,:E,:V),(:tgt,:E,:V)],[:Weight],
-                   [(:weight,:E,:Weight)], [(:E,:V,((:src,),(:tgt,)))])
+                   [(:weight,:E,:Weight)], [(nothing, :E,:V,((:src,),(:tgt,)))])
 tsch = typelevel(bsch)
 for sch in [bsch, tsch]
   @test collect(ob(sch)) == collect(objects(sch)) == [:E,:V]
@@ -20,7 +20,7 @@ for sch in [bsch, tsch]
   @test codom_nums(sch) == (2,2)
   @test adom_nums(sch) == (1,)
   @test acodom_nums(sch) == (1,)
-  @test collect(equations(sch)) == [(:E,:V,((:src,),(:tgt,)),)]
+  @test collect(equations(sch)) == [(nothing, :E,:V,((:src,),(:tgt,)),)]
 end
 
 @test attrtype_instantiation(tsch, Tuple{Int}, :Weight) == Int

--- a/test/Schemas.jl
+++ b/test/Schemas.jl
@@ -3,7 +3,8 @@ module TestSchemas
 using Test
 using ACSets.Schemas
 
-bsch = BasicSchema([:E,:V], [(:src,:E,:V),(:tgt,:E,:V)],[:Weight],[(:weight,:E,:Weight)])
+bsch = BasicSchema([:E,:V], [(:src,:E,:V),(:tgt,:E,:V)],[:Weight],
+                   [(:weight,:E,:Weight)], [(:E,:V,((:src,),(:tgt,)))])
 tsch = typelevel(bsch)
 for sch in [bsch, tsch]
   @test collect(ob(sch)) == collect(objects(sch)) == [:E,:V]
@@ -19,6 +20,7 @@ for sch in [bsch, tsch]
   @test codom_nums(sch) == (2,2)
   @test adom_nums(sch) == (1,)
   @test acodom_nums(sch) == (1,)
+  @test collect(equations(sch)) == [(:E,:V,((:src,),(:tgt,)),)]
 end
 
 @test attrtype_instantiation(tsch, Tuple{Int}, :Weight) == Int

--- a/test/Schemas.jl
+++ b/test/Schemas.jl
@@ -3,6 +3,8 @@ module TestSchemas
 using Test
 using ACSets.Schemas
 
+@test BasicSchema{Symbol}() isa BasicSchema
+
 bsch = BasicSchema([:E,:V], [(:src,:E,:V),(:tgt,:E,:V)],[:Weight],
                    [(:weight,:E,:Weight)], [(nothing, :E,:V,((:src,),(:tgt,)))])
 tsch = typelevel(bsch)

--- a/test/serialization/JSONACSets.jl
+++ b/test/serialization/JSONACSets.jl
@@ -42,7 +42,8 @@ add_parts!(g, :V, 3)
 add_parts!(g, :E, 2, src=[1,2], tgt=[2,3], weight=[0.5,1.5])
 @test roundtrip_json_acset(g) == g
 
-SchLabeledDDS = BasicSchema([:X], [(:Φ,:X,:X)], [:Label], [(:label,:X,:Label)])
+SchLabeledDDS = BasicSchema([:X], [(:Φ,:X,:X)], [:Label], [(:label,:X,:Label)], 
+                            [(:X,:X,((),(:Φ,:Φ,:Φ,:Φ)))])
 @acset_type LabeledDDS(SchLabeledDDS, index=[:Φ])
 
 ldds = LabeledDDS{Symbol}()

--- a/test/serialization/JSONACSets.jl
+++ b/test/serialization/JSONACSets.jl
@@ -42,11 +42,11 @@ add_parts!(g, :V, 3)
 add_parts!(g, :E, 2, src=[1,2], tgt=[2,3], weight=[0.5,1.5])
 @test roundtrip_json_acset(g) == g
 
-SchLabeledDDS = BasicSchema([:X], [(:Φ,:X,:X)], [:Label], [(:label,:X,:Label)], 
-                            [(:cycle4,:X,:X,((),(:Φ,:Φ,:Φ,:Φ)))])
-@acset_type LabeledDDS(SchLabeledDDS, index=[:Φ])
+SchLabeledDDS4 = BasicSchema([:X], [(:Φ,:X,:X)], [:Label], [(:label,:X,:Label)], 
+                             [(:cycle4,:X,:X,((),(:Φ,:Φ,:Φ,:Φ)))])
+@acset_type LabeledDDS4(SchLabeledDDS4, index=[:Φ])
 
-ldds = LabeledDDS{Symbol}()
+ldds = LabeledDDS4{Symbol}()
 add_parts!(ldds, :Label, 2)
 add_parts!(ldds, :X, 4, Φ=[2,3,4,1], label=[AttrVar(1), :a, :b, AttrVar(2)])
 @test roundtrip_json_acset(ldds) == ldds
@@ -68,7 +68,7 @@ end
 
 json_schema = JSONSchema.Schema(acset_schema_json_schema())
 
-for schema in [SchGraph, SchWeightedGraph, SchLabeledDDS]
+for schema in [SchGraph, SchWeightedGraph, SchLabeledDDS4]
   schema_dict = generate_json_acset_schema(schema)
   @test isnothing(JSONSchema.validate(json_schema, schema_dict))
   @test roundtrip_json_acset_schema(schema) == schema

--- a/test/serialization/JSONACSets.jl
+++ b/test/serialization/JSONACSets.jl
@@ -43,7 +43,7 @@ add_parts!(g, :E, 2, src=[1,2], tgt=[2,3], weight=[0.5,1.5])
 @test roundtrip_json_acset(g) == g
 
 SchLabeledDDS = BasicSchema([:X], [(:Φ,:X,:X)], [:Label], [(:label,:X,:Label)], 
-                            [(:X,:X,((),(:Φ,:Φ,:Φ,:Φ)))])
+                            [(:cycle4,:X,:X,((),(:Φ,:Φ,:Φ,:Φ)))])
 @acset_type LabeledDDS(SchLabeledDDS, index=[:Φ])
 
 ldds = LabeledDDS{Symbol}()


### PR DESCRIPTION
Currently we jump through a lot of hoops in Catlab and downstream packages whenever we actually need equations (e.g. computing representables), as this data lives in the Presentation but not in the ACSet schema. This PR adds this data to the schema.

GATlab presentations do not have named equations, but this is supported anyways in case we choose to add it later.