### PR TITLE
Accessor `getvalue` and better bounds checks for `set_subpart!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -32,7 +32,7 @@ NautyACSetsExt = "nauty_jll"
 XLSXACSetsExt = "XLSX"
 
 [compat]
-AlgebraicInterfaces = "0.1.3"
+AlgebraicInterfaces = "0.1.4"
 Base64 = "1.9"
 CompTime = "0.1"
 DataStructures = "0.18"

--- a/src/ColumnImplementations.jl
+++ b/src/ColumnImplementations.jl
@@ -18,9 +18,12 @@ our Attr Variable indices with the Julia type of Int
 """
 @struct_hash_equal struct AttrVar 
   val::Int 
-end 
+end
+
 getvalue(v::AttrVar) = v.val
-Base.isless(x::AttrVar,y::AttrVar) = getvalue(x) < getvalue(y)
+
+Base.isless(x::AttrVar, y::AttrVar) = getvalue(x) < getvalue(y)
+
 Base.convert(::Type{T}, x::T) where {T>:Union{Nothing,AttrVar}} = x
 Base.convert(::Type{T}, x::T) where {T>:Union{Missing,AttrVar}} = x
 Base.convert(::Type{T}, x::T) where {T>:AttrVar} = x

--- a/src/ColumnImplementations.jl
+++ b/src/ColumnImplementations.jl
@@ -1,11 +1,14 @@
 module ColumnImplementations
 export column_type, indexchoice,
-  HomChoice, AttrChoice, NoIndex, Index, UniqueIndex, Sparse, Dense, AttrVar 
+  HomChoice, AttrChoice, NoIndex, Index, UniqueIndex, Sparse, Dense, AttrVar,
+  getvalue
 
 using MLStyle
 using StructEquality
 using ..IndexUtils
 using ..Columns
+
+import AlgebraicInterfaces: getvalue
 
 
 """
@@ -16,7 +19,8 @@ our Attr Variable indices with the Julia type of Int
 @struct_hash_equal struct AttrVar 
   val::Int 
 end 
-Base.isless(x::AttrVar,y::AttrVar) = x.val < y.val
+getvalue(v::AttrVar) = v.val
+Base.isless(x::AttrVar,y::AttrVar) = getvalue(x) < getvalue(y)
 Base.convert(::Type{T}, x::T) where {T>:Union{Nothing,AttrVar}} = x
 Base.convert(::Type{T}, x::T) where {T>:Union{Missing,AttrVar}} = x
 Base.convert(::Type{T}, x::T) where {T>:AttrVar} = x

--- a/src/serialization/JSONACSets.jl
+++ b/src/serialization/JSONACSets.jl
@@ -39,7 +39,7 @@ function generate_json_acset(X::ACSet)
   return result
 end
 
-attr_to_json(var::AttrVar) = (_var = var.val,)
+attr_to_json(var::AttrVar) = (_var = getvalue(var),)
 attr_to_json(val) = val
 
 """ Parse JSON-able object or JSON string representing an ACSet.

--- a/test/ACSets.jl
+++ b/test/ACSets.jl
@@ -204,7 +204,7 @@ for dds_maker in dds_makers
   @test_throws AssertionError add_part!(dds, :X, Φ=5)
   @test nparts(dds, :X) == 3
   @test subpart(dds, :Φ) == [1,1,1]
-  @test_throws AssertionError add_parts!(dds, :X, 2, Φ=[3,6])
+  @test_throws AssertionError add_parts!(dds, :X, 2, Φ=[3,8])
   @test nparts(dds, :X) == 3
   @test incident(dds, 3, :Φ) == []
 
@@ -297,7 +297,7 @@ for (dgram_maker, ldgram_maker) in dgram_makers
 
   # Copying parts.
   d2 = dgram_maker(Int)
-  copy_parts!(d2, d, X=[4,5], R=[A.val])
+  copy_parts!(d2, d, X=[4,5], R=[getvalue(A)])
   @test nparts(d2, :X) == 2
   @test subpart(d2, [1,2], :parent) == [2,2]
   @test subpart(d2, [1,2], :height) == [10, AttrVar(1)]
@@ -305,7 +305,7 @@ for (dgram_maker, ldgram_maker) in dgram_makers
   du = disjoint_union(d, d2)
   @test nparts(du, :X) == 7
   @test subpart(du, :parent) == [4,4,4,5,5,7,7]
-  @test subpart(du, :height) == [0,0,0,10,A,10,AttrVar(A.val+1)]
+  @test subpart(du, :height) == [0,0,0,10,A,10,AttrVar(getvalue(A)+1)]
 
   # Pretty printing of data attributes.
   s = sprint(show, d)


### PR DESCRIPTION
Addresses https://github.com/AlgebraicJulia/ACSets.jl/issues/144

Previously, `set_subpart!` did bounds-checking when setting a hom, but not an Attr. An analogous check is added in this PR.

In the course of addressing that, it was clear that `set_subpart!` had a bug in virtue of not distinguishing between DenseParts and MarkAsDeleted ACSets for doing its bounds checking of homs.

This is also an opportunity to introduce `getvalue` as a functional way to get the wrapped value of an AttrVar. Because of this, this PR depends on this change to AlgebraicInterfaces: https://github.com/AlgebraicJulia/AlgebraicInterfaces.jl/pull/1