### PR TITLE
`values` now returns copy for SortedSet

### DIFF
--- a/src/IndexUtils.jl
+++ b/src/IndexUtils.jl
@@ -43,7 +43,7 @@ Base.in(s::SortedSet{T}, x::T) where {T} = begin
   i <= length(a) && a[i] == x
 end
 
-Base.values(s::SortedSet) = s.v
+Base.values(s::SortedSet) = copy(s.v)
 Base.length(s::SortedSet) = length(s.v)
 
 end

--- a/test/IndexUtils.jl
+++ b/test/IndexUtils.jl
@@ -22,4 +22,10 @@ ss2 = copy(ss)
 push!(ss2, 3)
 @test length.([ss,ss2]) == [1,2]
 
+push!(ss, 1)
+vals = values(ss)
+@test vals == [1,2]
+setdiff!(vals, 1)
+@test values(ss) == [1,2]
+
 end # module


### PR DESCRIPTION
This will address #168, it is a slightly strange way to address the issue but I believe this makes the most sense based on 2 points:

* Based on the comment in https://github.com/AlgebraicJulia/ACSets.jl/blob/main/src/ACSetInterface.jl#L200-L206 it seems that we assume `incident` is returning a copy every time anyway
* It seems reasonable to assume `SortedSet` would return a copy of its values to avoid changing them, and as far as I can see would not cause problems with the other parts of the `AbstractSet` interface it implements

Not sure if this is appropriate for `SortedSet` though. Happy to go the long way, that is passing `copy::Bool` around as a kwarg throughout the various `incident` overloads to make sure that when we use `StoredPreimageCache` the result is indeed copied but it seemed like that would be somewhat onerous.